### PR TITLE
Pass LoggerCLI instances to Config struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,9 +72,16 @@ type Config struct {
 	// typenames, etc)
 	Focus *Focus
 
+	// Logger is an instance of the LoggerCLI, already created
+	// by the lib user.
+	//
+	// Note that by using this field, the value of the LogFlags
+	// field will be ignored
+	Logger LoggerCLI
+
 	// LogFlags controls the logging configuration of the parser.
-	// It can be set using the constants LogTrace, LogDebug and
-	// LogJSON.
+	// It can be set using the constants LogTrace, LogDebug, LogJSON,
+	// etc. If the Logger field is set, this field will be ignored.
 	//
 	// Note that you can use a bitwise-AND operator to combine
 	// multiple flags
@@ -83,7 +90,7 @@ type Config struct {
 
 // packagesLoadConfig returns the configuration struct that is used to
 // call the packages.Load function
-func packagesLoadConfig(config Config, log LoggerCLI) *packages.Config {
+func packagesLoadConfig(config Config) *packages.Config {
 	if config.Fset == nil {
 		config.Fset = token.NewFileSet()
 	}
@@ -99,7 +106,7 @@ func packagesLoadConfig(config Config, log LoggerCLI) *packages.Config {
 		// Constant values, don't exposed
 		Mode: packagesConfigMode,
 		Logf: func(format string, args ...interface{}) {
-			log.Debug(format, args...)
+			config.Logger.Debug(format, args...)
 		},
 
 		// Not used

--- a/config_test.go
+++ b/config_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestConfig(t *testing.T) {
 	t.Run("If not provided, FileSet should be created", func(t *testing.T) {
-		config := Config{Fset: nil}
-		packagesConfig := packagesLoadConfig(config, loggerCLI.New(true, LogDebug|LogTrace))
+		config := Config{Fset: nil, Logger: loggerCLI.New(true, LogDebug|LogTrace)}
+		packagesConfig := packagesLoadConfig(config)
 		if packagesConfig.Fset == nil {
 			t.Fatal("Fset was expected to be not nil")
 		}
 	})
 	t.Run("The PackagesMode should be equal to the defined constant", func(t *testing.T) {
-		packagesConfig := packagesLoadConfig(Config{}, loggerCLI.New(true, LogDebug|LogTrace))
+		packagesConfig := packagesLoadConfig(Config{Logger: loggerCLI.New(true, LogDebug|LogTrace)})
 		if packagesConfig.Mode != packagesConfigMode {
 			t.Fatal("The mode is not set correctly")
 		}
@@ -37,14 +37,14 @@ func TestConfig(t *testing.T) {
 			return mock
 		}
 
-		packagesConfig := packagesLoadConfig(Config{}, mock)
+		packagesConfig := packagesLoadConfig(Config{Logger: mock})
 		packagesConfig.Logf(logMsg, logArgs...)
 		if debugCalls != 1 {
 			t.Fatalf("LogCLI Debug was expected to be called one time")
 		}
 	})
 	t.Run("PackagesConfig Context, ParseFile and Overlay should be always nil", func(t *testing.T) {
-		packagesConfig := packagesLoadConfig(Config{}, loggerCLI.New(true, LogDebug|LogTrace))
+		packagesConfig := packagesLoadConfig(Config{Logger: loggerCLI.New(true, LogDebug|LogTrace)})
 		if packagesConfig.Context != nil {
 			t.Fatalf("Context was expected to be nil")
 		}
@@ -62,8 +62,9 @@ func TestConfig(t *testing.T) {
 			Env:        []string{"a", "b", "c"},
 			BuildFlags: []string{"1", "2", "3"},
 			Fset:       token.NewFileSet(),
+			Logger:     loggerCLI.New(true, LogDebug|LogTrace),
 		}
-		packagesConfig := packagesLoadConfig(config, loggerCLI.New(true, LogDebug|LogTrace))
+		packagesConfig := packagesLoadConfig(config)
 		if packagesConfig.Tests != config.Tests {
 			t.Fatalf("PackagesConfig.Tests was expected to be equal to config.Tests")
 		}

--- a/new.go
+++ b/new.go
@@ -57,9 +57,14 @@ type GoParser struct {
 //		 might be matched by multiple patterns: in general it is not possible
 //		 to determine which packages correspond to which patterns.
 func NewGoParser(pattern string, config Config) (*GoParser, error) {
-	logger := loggerCLI.New(config.LogFlags&LogJSON != 0, config.LogFlags&(^LogJSON))
+	logger := config.Logger
+	if logger == nil {
+		logger = loggerCLI.New(config.LogFlags&LogJSON != 0, config.LogFlags&(^LogJSON))
+	}
 	printFinalConfig(pattern, config, logger)
-	packagesLoadConfig := packagesLoadConfig(config, logger)
+
+	config.Logger = logger
+	packagesLoadConfig := packagesLoadConfig(config)
 	pkgs, e := packages.Load(packagesLoadConfig, pattern)
 	if e != nil {
 		return nil, e

--- a/new_test.go
+++ b/new_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/mathbalduino/go-log/loggerCLI"
 	"go/token"
 	"testing"
 )
@@ -24,7 +25,30 @@ func TestNewGoParser(t *testing.T) {
 			t.Fatalf("GoParser expected to be not nil")
 		}
 	})
-	t.Run("The returned GoParser pkgs, focus, log and fileSet should be filled", func(t *testing.T) {
+	t.Run("The returned GoParser pkgs, focus, log (given by the user) and fileSet fields should be filled", func(t *testing.T) {
+		logger := loggerCLI.New(false, 0)
+		config := Config{Focus: &Focus{}, Fset: token.NewFileSet(), Logger: logger}
+		p, _ := NewGoParser("--inexistentPackage--", config)
+		if p == nil {
+			t.Fatalf("GoParser expected to be not nil")
+		}
+		if p.pkgs == nil {
+			t.Fatalf("GoParser.pkgs expected to be not nil")
+		}
+		if p.focus != config.Focus {
+			t.Fatalf("GoParser.focus expected to be equal to config.Focus")
+		}
+		if p.logger == nil {
+			t.Fatalf("GoParser.log expected to not be nil")
+		}
+		if p.logger != logger {
+			t.Fatalf("GoParser.log expected to not be nil")
+		}
+		if p.fileSet != config.Fset {
+			t.Fatalf("GoParser.fileSet expected to be equal to config.Fset")
+		}
+	})
+	t.Run("The returned GoParser pkgs, focus, log (dynamically created) and fileSet fields should be filled", func(t *testing.T) {
 		config := Config{Focus: &Focus{}, Fset: token.NewFileSet()}
 		p, _ := NewGoParser("--inexistentPackage--", config)
 		if p == nil {

--- a/printFinalConfig.go
+++ b/printFinalConfig.go
@@ -6,7 +6,7 @@ import (
 )
 
 // printFinalConfig will print, as a Debug log, the final configuration of the parser
-func printFinalConfig(pattern string, config Config, log LoggerCLI) {
+func printFinalConfig(pattern string, config Config, logger LoggerCLI) {
 	focus := nilFocusStr
 	if config.Focus != nil {
 		packagePath, filePath, typeName := "nil", "nil", "nil"
@@ -33,8 +33,15 @@ func printFinalConfig(pattern string, config Config, log LoggerCLI) {
 		dir = config.Dir
 	}
 
-	logFlags := "-"
-	if config.LogFlags != 0 {
+	loggerMsg := nilLoggerStr
+	if config.Logger != nil {
+		loggerMsg = notNilLoggerStr
+	}
+
+	logFlags := emptyLogFlagsStr
+	if config.Logger != nil {
+		logFlags = ignoredLogFlagsStr
+	} else if config.LogFlags != 0 {
 		if config.LogFlags&LogJSON != 0 {
 			logFlags = "LogJSON | "
 		}
@@ -59,7 +66,7 @@ func printFinalConfig(pattern string, config Config, log LoggerCLI) {
 		logFlags = strings.TrimSuffix(logFlags, " | ")
 	}
 
-	log.Debug(finalConfigTemplate,
+	logger.Debug(finalConfigTemplate,
 		pattern,
 		config.Tests,
 		dir,
@@ -67,6 +74,7 @@ func printFinalConfig(pattern string, config Config, log LoggerCLI) {
 		config.BuildFlags,
 		focus,
 		fset,
+		loggerMsg,
 		logFlags,
 	)
 }
@@ -75,6 +83,10 @@ const emptyDirStr = "./"
 const nilFsetStr = "Using the FileSet of the library"
 const notNilFsetStr = "Using the FileSet provided by the client"
 const nilFocusStr = "Focus not defined (will not skip anything)"
+const nilLoggerStr = "Logger not defined (will be created using LogFlags)"
+const notNilLoggerStr = "Using the Logger instance provided by the client"
+const emptyLogFlagsStr = "unset"
+const ignoredLogFlagsStr = "Ignored (Logger field is set)"
 
 const finalConfigTemplate = `New GoParser created. Final configuration:
 Pattern: %s
@@ -85,6 +97,7 @@ Config: {
 	BuildFlags: %v
 	Focus: %s
 	Fset: %s
+	Logger: %s
 	LogFlags: %s
 }`
 

--- a/printFinalConfig_test.go
+++ b/printFinalConfig_test.go
@@ -2,19 +2,21 @@ package parser
 
 import (
 	"fmt"
+	"github.com/mathbalduino/go-log/loggerCLI"
 	"go/token"
 	"reflect"
 	"testing"
 )
 
 func TestPrintFinalConfig(t *testing.T) {
-	t.Run("Print the correct final configuration when focus, fset and dir are nil", func(t *testing.T) {
+	t.Run("Print the correct final configuration when focus, fset, dir and logger are nil", func(t *testing.T) {
 		config := Config{
 			true,
 			"",
 			[]string{},
 			nil,
 			[]string{},
+			nil,
 			nil,
 			0,
 		}
@@ -27,7 +29,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -51,7 +53,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != nilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "-" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != emptyLogFlagsStr {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -61,13 +66,15 @@ func TestPrintFinalConfig(t *testing.T) {
 			t.Fatalf("Log.Debug was expected to be called one time")
 		}
 	})
-	t.Run("Print the correct final configuration when focus and dir are nil", func(t *testing.T) {
+	t.Run("Print the correct final configuration when fset, dir and logger are nil (focus pkg)", func(t *testing.T) {
+		focusStr := "somePackagePath"
 		config := Config{
 			true,
 			"",
 			[]string{},
-			token.NewFileSet(),
+			nil,
 			[]string{},
+			FocusPackagePath(focusStr),
 			nil,
 			0,
 		}
@@ -80,7 +87,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -98,13 +105,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			if !reflect.DeepEqual(args[4].([]string), config.BuildFlags) {
 				t.Fatalf("Wrong Log.Debug BuildFlags slice")
 			}
-			if args[5].(string) != nilFocusStr {
+			if args[5].(string) != fmt.Sprintf(focusTemplate, focusStr, "nil", "nil") {
 				t.Fatalf("Wrong Log.Debug focus string")
 			}
-			if args[6].(string) != notNilFsetStr {
+			if args[6].(string) != nilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "-" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != emptyLogFlagsStr {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -114,13 +124,15 @@ func TestPrintFinalConfig(t *testing.T) {
 			t.Fatalf("Log.Debug was expected to be called one time")
 		}
 	})
-	t.Run("Print the correct final configuration when focus is nil", func(t *testing.T) {
+	t.Run("Print the correct final configuration when fset, dir and logger are nil (focus filepath)", func(t *testing.T) {
+		filepath := "someFilepath"
 		config := Config{
 			true,
-			"abc",
+			"",
 			[]string{},
-			token.NewFileSet(),
+			nil,
 			[]string{},
+			FocusFilePath(filepath),
 			nil,
 			0,
 		}
@@ -133,7 +145,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -142,7 +154,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[1].(bool) != config.Tests {
 				t.Fatalf("Wrong Log.Debug tests boolean")
 			}
-			if args[2].(string) != config.Dir {
+			if args[2].(string) != emptyDirStr {
 				t.Fatalf("Wrong Log.Debug dir string")
 			}
 			if !reflect.DeepEqual(args[3].([]string), config.Env) {
@@ -151,13 +163,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			if !reflect.DeepEqual(args[4].([]string), config.BuildFlags) {
 				t.Fatalf("Wrong Log.Debug BuildFlags slice")
 			}
-			if args[5].(string) != nilFocusStr {
+			if args[5].(string) != fmt.Sprintf(focusTemplate, "nil", filepath, "nil") {
 				t.Fatalf("Wrong Log.Debug focus string")
 			}
-			if args[6].(string) != notNilFsetStr {
+			if args[6].(string) != nilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "-" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != emptyLogFlagsStr {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -167,15 +182,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			t.Fatalf("Log.Debug was expected to be called one time")
 		}
 	})
-	t.Run("Print the correct final configuration, with FocusPackage", func(t *testing.T) {
-		focusStr := "somePackagePath"
+	t.Run("Print the correct final configuration when fset, dir and logger are nil (focus typeName)", func(t *testing.T) {
+		typeName := "someTypeName"
 		config := Config{
 			true,
-			"abc",
+			"",
 			[]string{},
-			token.NewFileSet(),
+			nil,
 			[]string{},
-			FocusPackagePath(focusStr),
+			FocusTypeName(typeName),
+			nil,
 			0,
 		}
 		log := &mockLoggerCLI{}
@@ -187,7 +203,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -196,7 +212,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[1].(bool) != config.Tests {
 				t.Fatalf("Wrong Log.Debug tests boolean")
 			}
-			if args[2].(string) != config.Dir {
+			if args[2].(string) != emptyDirStr {
 				t.Fatalf("Wrong Log.Debug dir string")
 			}
 			if !reflect.DeepEqual(args[3].([]string), config.Env) {
@@ -205,13 +221,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			if !reflect.DeepEqual(args[4].([]string), config.BuildFlags) {
 				t.Fatalf("Wrong Log.Debug BuildFlags slice")
 			}
-			if args[5].(string) != fmt.Sprintf(focusTemplate, focusStr, "nil", "nil") {
+			if args[5].(string) != fmt.Sprintf(focusTemplate, "nil", "nil", typeName) {
 				t.Fatalf("Wrong Log.Debug focus string")
 			}
-			if args[6].(string) != notNilFsetStr {
+			if args[6].(string) != nilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "-" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != emptyLogFlagsStr {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -221,15 +240,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			t.Fatalf("Log.Debug was expected to be called one time")
 		}
 	})
-	t.Run("Print the correct final configuration, with FocusFilePath", func(t *testing.T) {
-		focusStr := "someFilePath"
+	t.Run("Print the correct final configuration when dir and logger are nil", func(t *testing.T) {
+		typeName := "someTypeName"
 		config := Config{
 			true,
-			"abc",
+			"",
 			[]string{},
 			token.NewFileSet(),
 			[]string{},
-			FocusFilePath(focusStr),
+			FocusTypeName(typeName),
+			nil,
 			0,
 		}
 		log := &mockLoggerCLI{}
@@ -241,7 +261,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -250,7 +270,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[1].(bool) != config.Tests {
 				t.Fatalf("Wrong Log.Debug tests boolean")
 			}
-			if args[2].(string) != config.Dir {
+			if args[2].(string) != emptyDirStr {
 				t.Fatalf("Wrong Log.Debug dir string")
 			}
 			if !reflect.DeepEqual(args[3].([]string), config.Env) {
@@ -259,13 +279,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			if !reflect.DeepEqual(args[4].([]string), config.BuildFlags) {
 				t.Fatalf("Wrong Log.Debug BuildFlags slice")
 			}
-			if args[5].(string) != fmt.Sprintf(focusTemplate, "nil", focusStr, "nil") {
+			if args[5].(string) != fmt.Sprintf(focusTemplate, "nil", "nil", typeName) {
 				t.Fatalf("Wrong Log.Debug focus string")
 			}
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "-" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != emptyLogFlagsStr {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -275,15 +298,17 @@ func TestPrintFinalConfig(t *testing.T) {
 			t.Fatalf("Log.Debug was expected to be called one time")
 		}
 	})
-	t.Run("Print the correct final configuration, with FocusTypeName", func(t *testing.T) {
-		focusStr := "someTypeName"
+	t.Run("Print the correct final configuration when logger is not nil", func(t *testing.T) {
+		typeName := "someTypeName"
+		dir := "someDir"
 		config := Config{
 			true,
-			"abc",
+			dir,
 			[]string{},
 			token.NewFileSet(),
 			[]string{},
-			FocusTypeName(focusStr),
+			FocusTypeName(typeName),
+			loggerCLI.New(false, 0),
 			0,
 		}
 		log := &mockLoggerCLI{}
@@ -295,7 +320,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -304,7 +329,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[1].(bool) != config.Tests {
 				t.Fatalf("Wrong Log.Debug tests boolean")
 			}
-			if args[2].(string) != config.Dir {
+			if args[2].(string) != dir {
 				t.Fatalf("Wrong Log.Debug dir string")
 			}
 			if !reflect.DeepEqual(args[3].([]string), config.Env) {
@@ -313,13 +338,16 @@ func TestPrintFinalConfig(t *testing.T) {
 			if !reflect.DeepEqual(args[4].([]string), config.BuildFlags) {
 				t.Fatalf("Wrong Log.Debug BuildFlags slice")
 			}
-			if args[5].(string) != fmt.Sprintf(focusTemplate, "nil", "nil", focusStr) {
+			if args[5].(string) != fmt.Sprintf(focusTemplate, "nil", "nil", typeName) {
 				t.Fatalf("Wrong Log.Debug focus string")
 			}
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "-" {
+			if args[7].(string) != notNilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != ignoredLogFlagsStr {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -337,6 +365,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogJSON,
 		}
 		log := &mockLoggerCLI{}
@@ -348,7 +377,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -372,7 +401,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogJSON" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogJSON" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -390,6 +422,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogTrace,
 		}
 		log := &mockLoggerCLI{}
@@ -401,7 +434,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -425,7 +458,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogTrace" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogTrace" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -443,6 +479,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogDebug,
 		}
 		log := &mockLoggerCLI{}
@@ -454,7 +491,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -478,7 +515,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogDebug" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogDebug" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -496,6 +536,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogInfo,
 		}
 		log := &mockLoggerCLI{}
@@ -507,7 +548,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -531,7 +572,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogInfo" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogInfo" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -549,6 +593,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogWarn,
 		}
 		log := &mockLoggerCLI{}
@@ -560,7 +605,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -584,7 +629,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogWarn" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogWarn" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -602,6 +650,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogError,
 		}
 		log := &mockLoggerCLI{}
@@ -613,7 +662,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -637,7 +686,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogError" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogError" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -655,6 +707,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogFatal,
 		}
 		log := &mockLoggerCLI{}
@@ -666,7 +719,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -690,7 +743,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogFatal" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogFatal" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log
@@ -708,6 +764,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			token.NewFileSet(),
 			[]string{},
 			nil,
+			nil,
 			LogDebug,
 		}
 		log := &mockLoggerCLI{}
@@ -719,7 +776,7 @@ func TestPrintFinalConfig(t *testing.T) {
 			if msgFormat != finalConfigTemplate {
 				t.Fatalf("Wrong Log.Debug template")
 			}
-			if len(args) != 8 {
+			if len(args) != 9 {
 				t.Fatalf("Wrong Log.Debug variadic args")
 			}
 			if args[0].(string) != pattern {
@@ -743,7 +800,10 @@ func TestPrintFinalConfig(t *testing.T) {
 			if args[6].(string) != notNilFsetStr {
 				t.Fatalf("Wrong Log.Debug Fset string")
 			}
-			if args[7].(string) != "LogDebug" {
+			if args[7].(string) != nilLoggerStr {
+				t.Fatalf("Wrong Log.Debug Logger string")
+			}
+			if args[8].(string) != "LogDebug" {
 				t.Fatalf("Wrong Log.Debug LogFlags string")
 			}
 			return log


### PR DESCRIPTION
Allow the library users to give a `LoggerCLI` reference to the `Config` struct instead of relying on the dynamically created one